### PR TITLE
Modify bazel configs to update android deps and expose proper targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ijwb
 .clwb
 /coverage
+third_party/android/r8.jar

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -79,3 +79,21 @@ platform(
     ],
     visibility = ["//:__subpackages__"],
 )
+
+platform(
+    name = "android_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:android",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+platform(
+    name = "android_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:android",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,18 +76,21 @@ http_archive(
 )
 
 http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
+    name = "rules_android",
+    sha256 = "af84b69ab3d16dd1a41056286e6511f147a94ccea995603e13e934c915c1631c",
+    strip_prefix = "rules_android-0.6.0",
+    url = "https://github.com/bazelbuild/rules_android/releases/download/v0.6.0/rules_android-v0.6.0.tar.gz",
 )
 
 http_archive(
     name = "rules_android_ndk",
-    sha256 = "73eac2cf5f2fd009e8fb197346a2ca39f320b786985658de63a1dff0f12c53d5",
-    strip_prefix = "rules_android_ndk-72ca32741f27c3de69fdcb7a1aaf3ca59919ad8c",
-    url = "https://github.com/bazelbuild/rules_android_ndk/archive/72ca32741f27c3de69fdcb7a1aaf3ca59919ad8c.zip",
+    sha256 = "65aedff0cd728bee394f6fb8e65ba39c4c5efb11b29b766356922d4a74c623f5",
+    strip_prefix = "rules_android_ndk-0.1.2",
+    url = "https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.2/rules_android_ndk-v0.1.2.tar.gz",
 )
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+android_ndk_repository(name = "androidndk")
+register_toolchains("@androidndk//:all")
 
 http_file(
     name = "genhtml",

--- a/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -45,6 +45,24 @@ copy_file(
     ],
 )
 
+copy_file(
+    name = "jazzer_shaded_jar",
+    src = "//src/main/java/com/code_intelligence/jazzer:jazzer",
+    out = "jazzer.jar",
+    visibility = [
+        "//src/main/java/com/code_intelligence/jazzer/agent:__pkg__",
+    ],
+)
+
+copy_file(
+    name = "jazzer_bootstrap_jar",
+    src = "//src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap",
+    out = "jazzer_bootstrap.jar",
+    visibility = [
+        "//src/main/java/com/code_intelligence/jazzer/agent:__pkg__",
+    ],
+)
+
 java_binary (
     name = "r8",
     resources = [


### PR DESCRIPTION
This PR updates `rules_android` from 0.1.1 to 0.6.0, and `rules_android_ndk` from 72ca327 (may 2023) to 0.1.2, and adds the appropriate `register_toolchains()` call for the latter. It also exposes the Android target's `jazzer.jar` and `jazzer_bootstrap.jar` as proper targets/artifacts under `bazel-bin/`.