### PR TITLE
Added JSON configuration support for Jazzer

### DIFF
--- a/maven.bzl
+++ b/maven.bzl
@@ -21,6 +21,7 @@ JAZZER_JUNIT_COORDINATES = "com.code-intelligence:jazzer-junit:%s" % JAZZER_VERS
 
 # keep sorted
 MAVEN_ARTIFACTS = [
+    "com.google.code.gson:gson:2.8.6",
     "org.junit.jupiter:junit-jupiter-api:5.8.2",
     "org.junit.jupiter:junit-jupiter-engine:5.8.2",
     "org.junit.jupiter:junit-jupiter-params:5.8.2",
@@ -41,7 +42,6 @@ TEST_MAVEN_ARTIFACTS = [
         "com.fasterxml.jackson.core:jackson-core:2.12.1",
         "com.fasterxml.jackson.core:jackson-databind:2.12.1",
         "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1",
-        "com.google.code.gson:gson:2.8.6",
         "com.google.truth.extensions:truth-java8-extension:1.1.3",
         "com.google.truth.extensions:truth-liteproto-extension:1.1.3",
         "com.google.truth.extensions:truth-proto-extension:1.1.3",

--- a/src/main/java/com/code_intelligence/jazzer/agent/AgentInstaller.java
+++ b/src/main/java/com/code_intelligence/jazzer/agent/AgentInstaller.java
@@ -16,21 +16,28 @@ package com.code_intelligence.jazzer.agent;
 
 import static com.code_intelligence.jazzer.agent.AgentUtils.extractBootstrapJar;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarFile;
+import java.util.logging.Logger;
+
+import com.code_intelligence.jazzer.r8.R8Wrapper;
+
 import net.bytebuddy.agent.ByteBuddyAgent;
 
 public class AgentInstaller {
   private static final AtomicBoolean hasBeenInstalled = new AtomicBoolean();
-
+  private static final Logger logger = Logger.getLogger(AgentInstaller.class.getName());
   /**
    * Appends the parts of Jazzer that have to be visible to all classes, including those in the Java
    * standard library, to the bootstrap class loader path. Additionally, if enableAgent is true,
    * also enables the Jazzer agent that instruments classes for fuzzing.
    */
-  public static void install(boolean enableAgent) {
+  public static void install(boolean enableAgent, File customHooksJar) {
     // Only install the agent once.
     if (!hasBeenInstalled.compareAndSet(false, true)) {
       return;
@@ -38,6 +45,18 @@ public class AgentInstaller {
 
     Instrumentation instrumentation = ByteBuddyAgent.install();
     instrumentation.appendToBootstrapClassLoaderSearch(extractBootstrapJar());
+
+    if (customHooksJar != null) {
+      try {
+        instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(customHooksJar));
+        logger.info("Added external hooks jar to bootstrap: " + customHooksJar.getAbsolutePath());
+      } catch (IOException e) {
+        logger.warning("Failed to add external hooks jar due to error: " + e);
+      }
+    } else {
+      logger.warning("Jar for adding custom hooks is not present to add in bootstrap class loader search.");
+    }
+
     if (!enableAgent) {
       return;
     }

--- a/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -67,7 +67,6 @@ java_binary (
     name = "r8",
     resources = [
         ":jazzer_jar",
-        "jazzer_instrumentation_config.json",
     ],
     main_class = "com.code_intelligence.jazzer.r8.R8Wrapper",
     srcs = ["R8Wrapper.java"],

--- a/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -67,6 +67,7 @@ java_binary (
     name = "r8",
     resources = [
         ":jazzer_jar",
+        "jazzer_instrumentation_config.json",
     ],
     main_class = "com.code_intelligence.jazzer.r8.R8Wrapper",
     srcs = ["R8Wrapper.java"],
@@ -75,6 +76,16 @@ java_binary (
         "//src/main/java/com/code_intelligence/jazzer/driver:opt",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
         "//third_party/android:local_r8",
+        "//src/main/java/com/code_intelligence/jazzer/android:instrumentation_config",
+    ],
+)
+
+java_library(
+    name = "instrumentation_config",
+    srcs = ["InstrumentationConfig.java"],
+    deps = [
+        "@maven//:com_google_code_gson_gson",
+        "//sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers:constants",
     ],
 )
 

--- a/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -61,9 +63,12 @@ import java.util.stream.Collectors;
  *       "com.code_intelligence.jazzer.sanitizers.SqlInjection"
  *     ]
  *   },
- *   "custom_hooks": [
- *     "com.example.ExampleFuzzerHook"
- *   ]
+ *   "custom_hooks": {
+ *     "custom_hooks_classes": [
+ *       "com.code_intelligence.jazzer.hooks.ExampleFuzzerHooks"
+ *      ],
+ *     "custom_hooks_jar_path": "prebuilts/jazzer/libcustom_hooks.jar"
+ *   }
  * }
  *
  * Supplying this JSON configuration file is optional. If the file is not provided, all hooks
@@ -89,10 +94,18 @@ import java.util.stream.Collectors;
  * "enabled_hooks" is used, only the listed hooks will be enabled. Hooks must be written as
  * fully-qualified Java class names.
  *
- * ###3. `custom_hooks`
- * This array allows additional fully-qualified hook class names to be listed
- * outside the predefined set. Currently, this feature is not supported at runtime, but
- * support is planned for future versions.
+ * ### 3. `custom_hooks`
+ * This object allows users to define additional sanitizer hooks externally.
+ * It contains:
+ *   - `custom_hooks_classes`: an array of fully-qualified hook class names 
+ *      that should be activated during instrumentation and runtime.
+ *   - `custom_hooks_jar_path`: a path to the precompiled hooks JAR that contains 
+ *      these classes. This can be either an absolute path or a path relative to 
+ *      the current working directory. The JAR will be added to the bootstrap 
+ *      classpath to ensure proper visibility.
+ *
+ * Together, these fields enable integrating custom hooks without rebuilding 
+ * Jazzer itself. If omitted, no external hooks are loaded.
  */
 public class InstrumentationConfig {
 
@@ -101,6 +114,8 @@ public class InstrumentationConfig {
     private final String JAZZER_HOOKS = "jazzer_hooks";
     private final String INSTRUMENTATION_FILTERS = "instrumentation_filters";
     private final String CUSTOM_HOOKS = "custom_hooks";
+    private final String CUSTOM_HOOKS_CLASSES = "custom_hooks_classes";
+    private final String CUSTOM_HOOKS_JAR_PATH = "custom_hooks_jar_path";
     private final String INCLUDE_FILTER = "include_filter";
     private final String EXCLUDE_FILTER = "exclude_filter";
     private final String DISABLED_HOOKS = "disabled_hooks";
@@ -109,8 +124,11 @@ public class InstrumentationConfig {
     private final Map<String, Boolean> hookStates = new HashMap<>();
     private final List<String> includeFilter = new ArrayList<>();
     private final List<String> excludeFilter = new ArrayList<>();
+    private final List<String> customHooksClasses = new ArrayList<>();
     private final Path dumpClassesDir;
 
+    private File customHooksJar;
+    
     public InstrumentationConfig() {
         // Disable all the hooks by default
         for (String hook : Constants.SANITIZER_HOOK_NAMES) {
@@ -137,7 +155,9 @@ public class InstrumentationConfig {
                         parseInstrumentationFilter(json.getAsJsonObject(key));
                         break;
                     case CUSTOM_HOOKS:
-                        parseCustomHooks(json.getAsJsonArray(key));
+                        JsonObject hooksObj = json.getAsJsonObject(key);
+                        parseCustomHooksJarPath(hooksObj);
+                        parseCustomHooksClasses(hooksObj);
                         break;
                     default:
                         logger.warning("Unsupported top-level config entry: " + key);
@@ -160,7 +180,18 @@ public class InstrumentationConfig {
         addOptionIfNotEmpty(disabledHooks, "--disabled_hooks=", jazzerOpts);
         addOptionIfNotEmpty(includeFilter, "--instrumentation_includes=", jazzerOpts);
         addOptionIfNotEmpty(excludeFilter, "--instrumentation_excludes=", jazzerOpts);
+
+        if(customHooksJar != null){
+            addOptionIfNotEmpty(customHooksClasses, "--custom_hooks=", jazzerOpts);
+        }
         jazzerOpts.add("--dump_classes_dir=" + dumpClassesDir.toString());
+    }
+    
+    public File getCustomHooksJar() {
+        if(customHooksJar == null){
+            logger.warning("custom hooks jar has not provided.");
+        }
+        return customHooksJar;
     }
 
     private void parseJazzerHooks(JsonObject hooksObj) {
@@ -209,9 +240,34 @@ public class InstrumentationConfig {
         }
     }
 
-    private void parseCustomHooks(JsonArray hooksArray) {
-        // TODO: Add support for custom_hooks
-        logger.warning("custom_hooks option is not enabled yet.");
+    private void parseCustomHooksClasses(JsonObject hooksObj) {
+        if (hooksObj.has(CUSTOM_HOOKS_CLASSES)) {
+            JsonArray hooksArray = hooksObj.getAsJsonArray(CUSTOM_HOOKS_CLASSES);
+            for (JsonElement el : hooksArray) {
+                customHooksClasses.add(el.getAsString());
+            }
+        } else {
+            logger.warning("Expected 'custom_hooks_classes' entry not found in custom_hooks config.");
+        }
+    }
+
+    private void parseCustomHooksJarPath(JsonObject hooksObj) {
+        if (hooksObj.has(CUSTOM_HOOKS_JAR_PATH)) {
+            String customHooksJarPath = hooksObj.get(CUSTOM_HOOKS_JAR_PATH).getAsString();
+            if (customHooksJarPath != null && !customHooksJarPath.isBlank()) {
+                customHooksJar = new File(customHooksJarPath);
+                if (!customHooksJar.exists()) {
+                    logger.warning("Custom hooks jar not found at: " + customHooksJarPath 
+                        + ". Continuing without custom hooks.");
+                    customHooksJar = null;
+                    return;
+                }
+            } else {
+                logger.warning("No custom hooks jar path provided.");
+            }
+        } else {
+            logger.warning("Expected 'custom_hooks_jar_path' entry not found in custom_hooks config.");
+        }
     }
 
     private void addOptionIfNotEmpty(List<String> list, String flag, List<String> jazzerOpts) {

--- a/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.android;
+
+import com.code_intelligence.jazzer.sanitizers.Constants;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * InstrumentationConfig
+ *
+ * This class is responsible for parsing and holding configuration options for
+ * offline instrumentation in Jazzer. The configuration can be specified at compile 
+ * time from a JSON file.
+ *
+ * 
+ * Example JSON configuration:
+ *
+ * {
+ *   "instrumentation_filters": {
+ *     "include_filter": ["com.example.*"],
+ *     "exclude_filter": ["com.example.ignore.*"]
+ *   },
+ *   "jazzer_hooks": {
+ *     "enabled_hooks": [
+ *       "com.code_intelligence.jazzer.sanitizers.SqlInjection"
+ *     ],
+ *     "disabled_hooks": [
+ *       "com.code_intelligence.jazzer.sanitizers.SqlInjection"
+ *     ]
+ *   },
+ *   "custom_hooks": [
+ *     "com.example.ExampleFuzzerHook"
+ *   ]
+ * }
+ *
+ * Supplying this JSON configuration file is optional. If the file is not provided, all hooks
+ * listed in {@link com.code_intelligence.jazzer.sanitizers.Constants#SANITIZER_HOOK_NAMES}
+ * remain disabled by default. If the file is present, Jazzer loads configuration values
+ * from it at startup to determine instrumentation and sanitization behavior.
+ *
+ * The configuration file supports the following options:
+ * 
+ * ### 1. `instrumentation_filters`
+ * This object in the JSON supports two arrays: "include_filter"
+ * and "exclude_filter". Both arrays can contain wildcard patterns (for example,
+ * "com.example.*"). The include filter specifies which classes are eligible for
+ * instrumentation, while the exclude filter specifies which classes should be skipped
+ * during instrumentation.
+ *
+ * ### 2. `jazzer_hooks`
+ * This object controls which sanitization hooks are active. These hooks are
+ * defined in {@link com.code_intelligence.jazzer.sanitizers.Constants#SANITIZER_HOOK_NAMES}.
+ * By default, all such hooks are disabled unless specified otherwise in the configuration.
+ * Either "enabled_hooks" or "disabled_hooks" must be specified (but not both). If
+ * "disabled_hooks" is used, all hooks will be enabled except those listed. If
+ * "enabled_hooks" is used, only the listed hooks will be enabled. Hooks must be written as
+ * fully-qualified Java class names.
+ *
+ * ###3. `custom_hooks`
+ * This array allows additional fully-qualified hook class names to be listed
+ * outside the predefined set. Currently, this feature is not supported at runtime, but
+ * support is planned for future versions.
+ */
+public class InstrumentationConfig {
+
+    private final Logger logger = Logger.getLogger(InstrumentationConfig.class.getName());
+
+    private final String JAZZER_HOOKS = "jazzer_hooks";
+    private final String INSTRUMENTATION_FILTERS = "instrumentation_filters";
+    private final String CUSTOM_HOOKS = "custom_hooks";
+    private final String INCLUDE_FILTER = "include_filter";
+    private final String EXCLUDE_FILTER = "exclude_filter";
+    private final String DISABLED_HOOKS = "disabled_hooks";
+    private final String ENABLED_HOOKS = "enabled_hooks";
+
+    private final Map<String, Boolean> hookStates = new HashMap<>();
+    private final List<String> includeFilter = new ArrayList<>();
+    private final List<String> excludeFilter = new ArrayList<>();
+    private final Path dumpClassesDir;
+
+    public InstrumentationConfig() {
+        // Disable all the hooks by default
+        for (String hook : Constants.SANITIZER_HOOK_NAMES) {
+            hookStates.put(hook, false);
+        }
+
+        try {
+            dumpClassesDir = Files.createTempDirectory("instrumented_classes");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create dump_classes_dir", e);
+        }
+    }
+
+    public void updateFromJson(InputStream input) throws Exception {
+        try (InputStreamReader reader = new InputStreamReader(input, StandardCharsets.UTF_8)) {
+            JsonObject json = JsonParser.parseReader(reader).getAsJsonObject();
+
+            for (String key : json.keySet()) {
+                switch (key) {
+                    case JAZZER_HOOKS:
+                        parseJazzerHooks(json.getAsJsonObject(key));
+                        break;
+                    case INSTRUMENTATION_FILTERS:
+                        parseInstrumentationFilter(json.getAsJsonObject(key));
+                        break;
+                    case CUSTOM_HOOKS:
+                        parseCustomHooks(json.getAsJsonArray(key));
+                        break;
+                    default:
+                        logger.warning("Unsupported top-level config entry: " + key);
+                }
+            }
+
+        } catch (Exception e) {
+            logger.warning("Failed to load instrumentation config.");
+            throw e;
+        }
+    }
+
+    public void addToJazzerOpts(List<String> jazzerOpts) {
+        // Collect disabled hooks
+        List<String> disabledHooks = hookStates.entrySet().stream()
+                .filter(entry -> !entry.getValue())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+        addOptionIfNotEmpty(disabledHooks, "--disabled_hooks=", jazzerOpts);
+        addOptionIfNotEmpty(includeFilter, "--instrumentation_includes=", jazzerOpts);
+        addOptionIfNotEmpty(excludeFilter, "--instrumentation_excludes=", jazzerOpts);
+        jazzerOpts.add("--dump_classes_dir=" + dumpClassesDir.toString());
+    }
+
+    private void parseJazzerHooks(JsonObject hooksObj) {
+        JsonArray enabled = hooksObj.has(ENABLED_HOOKS) ? hooksObj.getAsJsonArray(ENABLED_HOOKS) : null;
+        JsonArray disabled = hooksObj.has(DISABLED_HOOKS) ? hooksObj.getAsJsonArray(DISABLED_HOOKS) : null;
+
+        if (enabled != null && disabled != null) {
+            throw new IllegalArgumentException(
+                    "Invalid configuration: Only one of enabled_hooks or disabled_hooks can be specified.");
+        }
+
+        if (enabled != null) {
+            setHooks(enabled, true /* enabled state */);
+        } else if (disabled != null) {
+            hookStates.replaceAll((k, v) -> true);
+            setHooks(disabled, false /* disabled state */);
+        }
+    }
+
+    private void setHooks(JsonArray hooks, boolean state) {
+        for (JsonElement el : hooks) {
+            String hook = el.getAsString();
+            if (!hookStates.containsKey(hook)) {
+                logger.warning("Unknown hook in enabled_hooks: " + hook);
+            }
+            hookStates.put(hook, state);
+        }
+    }
+
+    private void parseInstrumentationFilter(JsonObject filterObj) {
+        for (String key : filterObj.keySet()) {
+            switch (key) {
+                case INCLUDE_FILTER:
+                    for (JsonElement el : filterObj.getAsJsonArray(key)) {
+                        includeFilter.add(el.getAsString());
+                    }
+                    break;
+                case EXCLUDE_FILTER:
+                    for (JsonElement el : filterObj.getAsJsonArray(key)) {
+                        excludeFilter.add(el.getAsString());
+                    }
+                    break;
+                default:
+                    logger.warning("Unknown key in instrumentation_filter: " + key);
+            }
+        }
+    }
+
+    private void parseCustomHooks(JsonArray hooksArray) {
+        // TODO: Add support for custom_hooks
+        logger.warning("custom_hooks option is not enabled yet.");
+    }
+
+    private void addOptionIfNotEmpty(List<String> list, String flag, List<String> jazzerOpts) {
+        if (list != null && !list.isEmpty()) {
+            jazzerOpts.add(flag + String.join(":", list));
+        }
+    }
+}

--- a/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
@@ -23,6 +23,7 @@ import main.java.com.code_intelligence.jazzer.android.InstrumentationConfig;
 import com.code_intelligence.jazzer.driver.OfflineInstrumentor;
 import com.code_intelligence.jazzer.driver.Opt;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ClassNotFoundException;
@@ -38,18 +39,22 @@ import java.util.logging.Logger;
 public class R8Wrapper {
   private static final Logger logger = Logger.getLogger(R8Wrapper.class.getName());
 
+  // Path to the instrumentation config file on the host.
+  // It is relative to the current working directory.
+  private static final String CONFIG_FILE_PATH = "prebuilts/jazzer/jazzer_instrumentation_config.json";
+  private static File customHooksJar;
+
   private static void setOptions() throws Exception {
     List<String> jazzerOpts = new ArrayList<>();
     // default config object will have all the default hooks disabled
     InstrumentationConfig config = new InstrumentationConfig();
 
-    InputStream input = R8Wrapper.class
-        .getClassLoader()
-        .getResourceAsStream("com/code_intelligence/jazzer/android/jazzer_instrumentation_config.json");
+    File configFile = new File(CONFIG_FILE_PATH);
 
-    if (input != null) {
-      try (InputStream in = input) {
-        config.updateFromJson(in);
+    if (configFile.exists()) {
+      try (FileInputStream fis = new FileInputStream(configFile)) {
+        config.updateFromJson(fis);
+        customHooksJar = config.getCustomHooksJar();
       }
     } else {
       logger.info("No instrumentation config found — using default config.");
@@ -71,7 +76,7 @@ public class R8Wrapper {
 
       // found com.android.tools.r8warpper.R8Wrapper
       // don't add native libs, we are in AOSP and Soong has special code for this
-      boolean instrumentationSuccess = OfflineInstrumentor.instrumentJars(jarfiles, false);
+      boolean instrumentationSuccess = OfflineInstrumentor.instrumentJars(jarfiles, false, customHooksJar);
       if (!instrumentationSuccess) {
         exit(1);
       }

--- a/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
@@ -18,30 +18,44 @@ package com.code_intelligence.jazzer.r8;
 
 import static java.lang.System.exit;
 
+import main.java.com.code_intelligence.jazzer.android.InstrumentationConfig;
+
 import com.code_intelligence.jazzer.driver.OfflineInstrumentor;
 import com.code_intelligence.jazzer.driver.Opt;
-import com.code_intelligence.jazzer.utils.Log;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.ClassNotFoundException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 public class R8Wrapper {
-  private static void setOptions() throws IOException {
-    Path dumpClassesDir = Files.createTempDirectory("instrumented_classes");
-    List<String> jazzerOpts = Arrays.asList("--dump_classes_dir=" + dumpClassesDir.toString());
+  private static final Logger logger = Logger.getLogger(R8Wrapper.class.getName());
 
+  private static void setOptions() throws Exception {
+    List<String> jazzerOpts = new ArrayList<>();
+    // default config object will have all the default hooks disabled
+    InstrumentationConfig config = new InstrumentationConfig();
+
+    InputStream input = R8Wrapper.class
+        .getClassLoader()
+        .getResourceAsStream("com/code_intelligence/jazzer/android/jazzer_instrumentation_config.json");
+
+    if (input != null) {
+      try (InputStream in = input) {
+        config.updateFromJson(in);
+      }
+    } else {
+      logger.info("No instrumentation config found — using default config.");
+    }
+
+    config.addToJazzerOpts(jazzerOpts);
     Opt.registerAndValidateCommandLineArgs(Opt.parseJazzerArgs(jazzerOpts));
   }
 
@@ -66,12 +80,11 @@ public class R8Wrapper {
       return;
     } catch (ClassNotFoundException cnfe) {
       // This is ok, we wouldn't expect this class to be found outside of AOSP
-      System.out.println("No wrapper function found");
+      logger.warning("No wrapper function found");
     }
 
     try {
-      Class<?> r8 =
-          Class.forName("com.android.tools.r8.R8", false, R8Wrapper.class.getClassLoader());
+      Class<?> r8 = Class.forName("com.android.tools.r8.R8", false, R8Wrapper.class.getClassLoader());
       MethodHandle main = MethodHandles.lookup().findStatic(
           r8, "main", MethodType.methodType(void.class, String[].class));
 
@@ -84,7 +97,7 @@ public class R8Wrapper {
 
       main.invokeExact(args);
     } catch (Exception e) {
-      System.out.println(e);
+      logger.warning(e);
     }
   }
 

--- a/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
@@ -49,9 +49,9 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipOutputStream;
 
 public class OfflineInstrumentor {
-  public static boolean instrumentJars(List<String> jarList, boolean addNativeLibs)
+  public static boolean instrumentJars(List<String> jarList, boolean addNativeLibs, File customHooksJar)
       throws IOException {
-    AgentInstaller.install(true);
+    AgentInstaller.install(true, customHooksJar);
     // TODO: as a working proof of concept, this has only been tested on one jar.
     // This should be fine for most scenarios since this should be happening directly
     // before dexing.


### PR DESCRIPTION
This commit adds supports for an instrumentation config file. This will enable easier configuration of instrumentation options, such as specifying include/exclude class filters and enabling or disabling sanitizers etc. 